### PR TITLE
Call isalpha() instead of isletter()

### DIFF
--- a/cptoml.py
+++ b/cptoml.py
@@ -51,7 +51,7 @@ def _linevalue(line):
         result = result[1:-1]
     elif result.isdigit() or (result[0] in ["-", "+"] and result[1:].isdigit()):  # ints
         result = int(result)
-    elif result[0] == "0" and result[1].isletter():  # other numeric
+    elif result[0] == "0" and result[1].isalpha():  # other numeric
         if result[1] == "x":  # hex
             result = hex(int(result[2:], 16))
         elif result[1] == "o":  # octal

--- a/cptoml.py
+++ b/cptoml.py
@@ -56,6 +56,8 @@ def _linevalue(line):
             result = hex(int(result[2:], 16))
         elif result[1] == "o":  # octal
             result = oct(int(result[2:], 8))
+        elif result[1] == "b":  # binary
+            result = bin(int(result[2:], 2))
         elif result[0].isdigit() and ("e" in result):  # notation
             exec(f"result = int({result})")
         else:


### PR DESCRIPTION
cptoml doesn't correctly parse non-decimal numeric values, ie ones that start with `0`. Changing the call to the nonexistent `isletter()` into `isalpha` solves that problem.

Also, this pull request adds support for numbers represented as binary, starting with `0b`