### PR TITLE
fix: prepare lines with \r\n at line end

### DIFF
--- a/cptoml.py
+++ b/cptoml.py
@@ -17,7 +17,7 @@ def _prepareline(line) -> str:
         )
     ):  # Without the -1 check eats a char
         line = line[: line.rfind("#")]
-    while line.endswith(" ") or line.endswith("\n"):
+    while line.endswith(" ") or line.endswith("\n") or line.endswith("\r"):
         line = line[:-1]
     while line.startswith(" "):
         line = line[1:]


### PR DESCRIPTION
thanks for the library! This pull request is required for me to work on my windows edited toml file.

my toml file originally comes with \r\n endings. \r needs to be removed as well. 

BR
TinkerPhu